### PR TITLE
fix: remove deprecated commands and post comments from file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,20 +51,9 @@ runs:
         max_lock_duration: ${{ inputs.max_lock_duration }}
         max_duration: ${{ inputs.max_duration }}
 
-    - id: comment-body
-      run: |
-        body="$(cat report.md)"
-        body="${body//'%'/'%25'}"
-        body="${body//$'\n'/'%0A'}"
-        body="${body//$'\r'/'%0D'}"
-        echo "::set-output name=body::$body"
-      shell: bash
-      working-directory: artifacts
-      if: ${{ always() }}
-
     - name: Post comment to PR
       if: ${{ always() && github.event_name == 'pull_request' }}
-      uses: peter-evans/create-or-update-comment@v2
+      uses: peter-evans/create-or-update-comment@v2.1.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
-        body: ${{ steps.comment-body.outputs.body }}
+        body-file: 'artifacts/report.md'

--- a/core/entrypoint.sh
+++ b/core/entrypoint.sh
@@ -43,8 +43,6 @@ if [[ $response_code -ne 200 ]]; then
   exit 1
 fi
 
-echo "::set-output name=response::$(cat response.json)"
-
 clone_id=$(jq -r '.clone_id' response.json)
 session_id=$(jq -r '.session.session_id' response.json)
 


### PR DESCRIPTION
#### Update action steps
- remove deprecated commands (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- post comments from file (https://github.com/peter-evans/create-or-update-comment/releases/tag/v2.1.0)

#### Example: 
https://github.com/postgres-ai/green-zone/pull/8#issuecomment-1294383873